### PR TITLE
Update README to reflect new download location

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,7 @@ git clone "hg::http://selenic.com/repo/hello"
 To enable this, simply add the 'git-remote-hg' script anywhere in your `$PATH`:
 
 --------------------------------------
-wget https://raw.github.com/felipec/git-remote-hg/master/git-remote-hg -O ~/bin/git-remote-hg
+wget https://raw.githubusercontent.com/felipec/git-remote-hg/master/git-remote-hg -O ~/bin/git-remote-hg
 chmod +x ~/bin/git-remote-hg
 --------------------------------------
 


### PR DESCRIPTION
Github seems to have moved to hosting files at githubusercontent.com.
