### PR TITLE
Fix "Branch name doesn't conform to GIT standards" error with transforma...

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -85,10 +85,10 @@ def hgbin(n):
     return node.bin(n)
 
 def hgref(ref):
-    return ref.replace('___', ' ')
+    return ref.replace('__DOT__', '.').replace('___', ' ')
 
 def gitref(ref):
-    return ref.replace(' ', '___')
+    return ref.replace('.', '__DOT__').replace(' ', '___')
 
 def check_version(*check):
     if not hg_version:


### PR DESCRIPTION
...tion

A hg repository I successfully cloned using git-hg-remote gave the
following error on subsequent use of "git fetch" in the
.git/fast_import_crash_XXXX log:

```
fatal: Branch name doesn't conform to GIT standards: BRANCH.
```

I guessed that it might be the use of the "." in the branch name in hg
and applied this patch to my copy of git-hg-remote.  That seemed to fix
the problem (and allowed a whole load of other tags into the clone that
had previously been skipped during the initial 'git clone hg::'
operation).

All this patch does is add to the transformations already present in
hgref() and gitref() to replace "." in hg refnames with "**DOT**" in the
git names.  It's not ideal, but it allowed me to successfully complete
the "git fetch".

I'm not entirely convinced that the error from "git fast-import" is
valid, as I've used "." myself in tag names in pure git repos in the
past without difficulty in the past.
