### PR TITLE
Update raw-file URL

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,7 @@ git clone "hg::http://selenic.com/repo/hello"
 To enable this, simply add the 'git-remote-hg' script anywhere in your `$PATH`:
 
 --------------------------------------
-wget https://raw.github.com/felipec/git-remote-hg/master/git-remote-hg -O ~/bin/git-remote-hg
+curl -o ~/bin/git-remote-hg https://raw.githubusercontent.com/felipec/git-remote-hg/master/git-remote-hg
 chmod +x ~/bin/git-remote-hg
 --------------------------------------
 


### PR DESCRIPTION
`raw.github.com` has been deprecated. This updates the installation instructions to use `curl`, as well as the `raw.githubusercontent.com` domain.