### PR TITLE
Ignore git submodules in fast-import stream

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -785,6 +785,9 @@ def parse_commit(parser):
     for line in parser:
         if parser.check('M'):
             t, m, mark_ref, path = line.split(' ', 3)
+            if m == '160000':
+                warn("Git submodules are not supported, ignoring '%s'", path)
+                continue
             mark = int(mark_ref[1:])
             f = { 'mode': hgmode(m), 'data': blob_marks[mark] }
         elif parser.check('D'):

--- a/test/bidi.t
+++ b/test/bidi.t
@@ -174,6 +174,38 @@ test_expect_success 'git tags' '
 	test_cmp expected actual
 '
 
+test_expect_success 'git submodules' '
+	test_when_finished "rm -rf gitrepo* hgrepo*" &&
+
+	(
+	git init -q gitrepo &&
+	cd gitrepo &&
+	echo alpha > alpha &&
+	git add alpha &&
+	git commit -m "add alpha" &&
+	git tag alpha &&
+
+    git init -q subrepo &&
+    cd subrepo
+	echo beta > beta &&
+	git add beta &&
+	git commit -m "add beta" &&
+
+	cd .. &&
+	git submodule add ./subrepo ext &&
+	git commit -m "add submodule"
+	) &&
+
+	hg_clone gitrepo hgrepo &&
+	git_clone hgrepo gitrepo2 &&
+	hg_clone gitrepo2 hgrepo2 &&
+
+	hg_log hgrepo > expected &&
+	hg_log hgrepo2 > actual &&
+
+	test_cmp expected actual
+'
+
 test_expect_success 'hg branch' '
 	test_when_finished "rm -rf gitrepo* hgrepo*" &&
 


### PR DESCRIPTION
There is no way to map them to mercurial, but this way one retains at
least some interoperability.

An alternative approach would be to export these as (fake) files or fake symlinks or so. This would allow hg users to at least remove submodule files. But on the other hand it could cause all kinds of complications if abused. Anyway, the patch as-is works for my use cases so far.

Fixes #22