### PR TITLE
Normalize the path using replace().

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -265,7 +265,7 @@ class Parser:
         return (user, int(date), -tz)
 
 def fix_file_path(path):
-    path = os.path.normpath(path)
+    path.replace('//', '/')
     if not os.path.isabs(path):
         return path
     return os.path.relpath(path, '/')

--- a/git-remote-hg
+++ b/git-remote-hg
@@ -265,7 +265,7 @@ class Parser:
         return (user, int(date), -tz)
 
 def fix_file_path(path):
-    path.replace('//', '/')
+    path = path.replace('//', '/')
     if not os.path.isabs(path):
         return path
     return os.path.relpath(path, '/')


### PR DESCRIPTION
On Windows `os.path.normpath()` will add backslashes and quotes to the path which git can't handle.

The original commit 978314a4be4d51ceaca8bf8359b29289b16d2691 mentions that the intention for `os.path.normpath()` was to normalize paths with 'foo//bar'. Thus to make sure we don't get unintended consequences I suggest a manual replacement.
