### PR TITLE
Timezone fix

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -72,7 +72,38 @@ def gitmode(flags):
     return 'l' in flags and '120000' or 'x' in flags and '100755' or '100644'
 
 def gittz(tz):
-    return '%+03d%02d' % (-tz / 3600, -tz % 3600 / 60)
+    """ Converts UTC-offset (in negated seconds) to "+HHmm" notation.
+
+    Examples:
+    >>> gittz_fixed(-1*3600)        # Paris
+    '+0100'
+    >>> gittz_fixed(5*3600)         # New York
+    '-0500'
+    >>> gittz_fixed(int(3.5*3600))  # St. John\'s
+    '-0330'
+    >>> gittz_fixed(int(-3.5*3600)) # Tehran
+    '+0330'
+    """
+    sign = 1 if tz < 0 else -1
+    return '%+03d%02d' % (sign * (abs(tz) / 3600), abs(tz) % 3600 / 60)
+
+def pytz(tz):
+    """ Converts timezone in "+HHmm" notation to UTC-offset (in negated seconds).
+
+    Examples:
+    >>> pytz_fixed('+0100')   # Paris
+    -3600
+    >>> pytz_fixed('-0500')   # New York
+    18000
+    >>> pytz_fixed('-0330')   # St. John\'s (fails!)
+    12600
+    >>> pytz_fixed('+0330')   # Tehran
+    -12600
+    """
+    tz = int(tz)
+    sign = 1 if tz < 0 else -1
+    tz = (( abs(tz) / 100 ) * 3600) + (( abs(tz) % 100) * 60)
+    return  sign * tz
 
 def hgmode(mode):
     m = { '100755': 'x', '120000': 'l' }
@@ -260,9 +291,7 @@ class Parser:
         if ex:
             user += ex
 
-        tz = int(tz)
-        tz = ((tz / 100) * 3600) + ((tz % 100) * 60)
-        return (user, int(date), -tz)
+        return (user, int(date), pytz(tz))
 
 def fix_file_path(path):
     path = os.path.normpath(path)

--- a/test/main.t
+++ b/test/main.t
@@ -1024,4 +1024,38 @@ test_expect_success 'clone replace directory with a file' '
 	check_files gitrepo "dir_or_file"
 '
 
+test_expect_success 'timezone issues' '
+	test_when_finished "rm -rf hgrepo gitrepo1 gitrepo2" &&
+
+	(
+		hg init hgrepo &&
+		cd hgrepo &&
+		echo one > content &&
+		hg add content &&
+		hg commit -m one
+	) &&
+
+	echo "Tue, 27 Sep 2016 00:00:00 -0230" > expected_timestamp &&
+
+	(
+		git clone "hg::hgrepo" gitrepo1 &&
+		cd gitrepo1 &&
+		echo two >> content &&
+		git add content &&
+		git commit -m two --date="$(cat ../expected_timestamp)" &&
+		git push &&
+		cd ..
+	) &&
+
+	git clone "hg::hgrepo" gitrepo2 &&
+
+	(
+		cd gitrepo2 &&
+		git log -1 --format="%aD" > ../actual_timestamp &&
+		cd ..
+	) &&
+
+	test_cmp expected_timestamp actual_timestamp
+'
+
 test_done


### PR DESCRIPTION
(Second try. )
As described in issue #48.
First commit adds test that demonstrates the issue:

```
HEAD is now at 6f29ffb... test for timezone issue
~/misc_projects/git-remote-hg/test $ make clean main.t 
rm -f -r 'trash directory'.* test-results
/bin/sh main.t 
ok 1 - setup
[...]
ok 34 - clone replace directory with a file
not ok 35 - timezone issues
#   
#       test_when_finished "rm -rf hgrepo gitrepo1 gitrepo2" &&
#   
[...]
#   
#       test_cmp expected_timestamp actual_timestamp
#   
# still have 3 known breakage(s)
# failed 1 among remaining 32 test(s)
1..35
make: *** [main.t] Error 1
~/misc_projects/git-remote-hg/test $ cat trash\ directory.main/tmp/*timestamp
Tue, 27 Sep 2016 00:20:00 -0210
Tue, 27 Sep 2016 00:00:00 -0230
```

The second commit introduces a change to fix it.
