### PR TITLE
Fix "Branch name doesn't conform to GIT standards"

### DIFF
--- a/git-remote-hg
+++ b/git-remote-hg
@@ -84,11 +84,20 @@ def hghex(n):
 def hgbin(n):
     return node.bin(n)
 
+def _rep_start_end(s, old, new):
+    while s.startswith(old):
+        s = new + s[len(old):]
+    while s.endswith(old):
+        s = s[:-len(old)] + new
+    return s
+
 def hgref(ref):
-    return ref.replace('___', ' ')
+    backwards_compat = ref.replace('___', ' ')
+    return _rep_start_end(urllib.unquote(backwards_compat), '.', '%2E')
 
 def gitref(ref):
-    return ref.replace(' ', '___')
+    backwards_compat = ref.replace(' ', '___')
+    return _rep_start_end(urllib.quote(backwards_compat), '%2E', '.')
 
 def check_version(*check):
     if not hg_version:


### PR DESCRIPTION
Resolves #74

Uses suggestion from @jan-hudec, using `urllib`, but keeping (at least some) backwards compatibility with existing source transforms.

Can supersede #7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/felipec/git-remote-hg/75)
<!-- Reviewable:end -->
